### PR TITLE
Update CI to make use of latest flutter-action

### DIFF
--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
 
     # Setup the flutter environment.
-    - uses: subosito/flutter-action@v1.4.0
+    - uses: subosito/flutter-action@v2
       with:
         channel: 'beta'
 


### PR DESCRIPTION
I was referencing v1.4, and it appears that it stopped installing the latest Flutter beta.