### PR TITLE
Fix intrinsic sizing for rows that contain width-in-height-out layout (e.g., wrapping text)

### DIFF
--- a/example/lib/periodic_table.dart
+++ b/example/lib/periodic_table.dart
@@ -31,6 +31,12 @@ class PeriodicTableApp extends StatelessWidget {
         builder: (_, __) {
           return LayoutBuilder(builder: (_, constraints) {
             _viewportSize = constraints.biggest;
+            // PeriodicTableWidget has many AtomicElementWidget widgets
+            // as part of its descendant widget tree, and they use global
+            // variable _viewportSize during build, so it's not safe to use
+            // const. If it were const, then this widget tree would only be
+            // constructed once and would not adapt as the viewport size
+            // changed.
             // ignore: prefer_const_constructors
             return SingleChildScrollView(child: PeriodicTableWidget());
           });

--- a/example/lib/periodic_table.dart
+++ b/example/lib/periodic_table.dart
@@ -31,7 +31,8 @@ class PeriodicTableApp extends StatelessWidget {
         builder: (_, __) {
           return LayoutBuilder(builder: (_, constraints) {
             _viewportSize = constraints.biggest;
-            return const SingleChildScrollView(child: PeriodicTableWidget());
+            // ignore: prefer_const_constructors
+            return SingleChildScrollView(child: PeriodicTableWidget());
           });
         },
       ),

--- a/example/lib/support/inner_shadow.dart
+++ b/example/lib/support/inner_shadow.dart
@@ -25,11 +25,12 @@ class InnerShadow extends SingleChildRenderObjectWidget {
 
   @override
   RenderInnerShadow createRenderObject(BuildContext context) {
-    return RenderInnerShadow()
-      ..color = color
-      ..blurX = blurX
-      ..blurY = blurY
-      ..offset = offset;
+    return RenderInnerShadow(
+      color: color,
+      blurX: blurX,
+      blurY: blurY,
+      offset: offset,
+    );
   }
 
   @override
@@ -46,15 +47,23 @@ class InnerShadow extends SingleChildRenderObjectWidget {
 class RenderInnerShadow extends RenderProxyBox {
   RenderInnerShadow({
     RenderBox? child,
-  }) : super(child);
+    required Color color,
+    required double blurX,
+    required double blurY,
+    required Offset offset,
+  })  : _color = color,
+        _blurX = blurX,
+        _blurY = blurY,
+        _offset = offset,
+        super(child);
 
   @override
   bool get alwaysNeedsCompositing => child != null;
 
-  late Color _color;
-  late double _blurX;
-  late double _blurY;
-  late Offset _offset;
+  Color _color;
+  double _blurX;
+  double _blurY;
+  Offset _offset;
 
   Color get color => _color;
   set color(Color value) {

--- a/lib/src/rendering/layout_grid.dart
+++ b/lib/src/rendering/layout_grid.dart
@@ -276,7 +276,7 @@ class RenderLayoutGrid extends RenderBox
 
   @override
   double computeMaxIntrinsicWidth(double height) =>
-      _computeIntrinsicSize(BoxConstraints(minHeight: height)).maxTracksWidth;
+      _computeIntrinsicSize(BoxConstraints(maxHeight: height)).maxTracksWidth;
 
   @override
   double computeMinIntrinsicHeight(double width) =>
@@ -285,7 +285,7 @@ class RenderLayoutGrid extends RenderBox
 
   @override
   double computeMaxIntrinsicHeight(double width) =>
-      _computeIntrinsicSize(BoxConstraints(minWidth: width)).maxTracksHeight;
+      _computeIntrinsicSize(BoxConstraints(maxWidth: width)).maxTracksHeight;
 
   // TODO(https://github.com/shyndman/flutter_layout_grid/issues/1):
   // This implementation is not likely to be correct. Revisit once Flutter's


### PR DESCRIPTION
Fixes #76.

Tested and verified that all layouts for the example app are correct (no visible differences before/after) after making this change. I believe this new behavior should be desired in all cases, so there is no widget option to change it.

Also make some minor fixes so the scrabble app can run on web on newer flutter versions, and so that the periodic table is redrawn properly on web platform as window resizes.