### PR TITLE
Replaced deprecated describeEnum with .name property

### DIFF
--- a/lib/src/rendering/layout_grid.dart
+++ b/lib/src/rendering/layout_grid.dart
@@ -483,7 +483,7 @@ class RenderLayoutGrid extends RenderBox
     final isAxisUpperBound = bounds.max.isFinite;
 
     if (debugPrintGridLayout) {
-      debugPrint('${describeEnum(typeBeingSized).toUpperCase()} tracks with a '
+      debugPrint('${typeBeingSized.name.toUpperCase()} tracks with a '
           'maximum free space of $initialFreeSpace, '
           'isAxisUpperBound=$isAxisUpperBound');
     }
@@ -595,7 +595,7 @@ class RenderLayoutGrid extends RenderBox
     BoxConstraints? constraints,
   ) {
     if (intrinsicTracks.isNotEmpty && debugPrintGridLayout) {
-      debugPrint('Resolving intrinsic ${describeEnum(type)} '
+      debugPrint('Resolving intrinsic ${type.name} '
           '${type == TrackType.column ? 'widths' : 'heights'} '
           '[${debugTrackIndicesString(intrinsicTracks)}]');
     }
@@ -732,7 +732,7 @@ class RenderLayoutGrid extends RenderBox
     if (debugPrintGridLayout) {
       debugPrint('  distributing $freeSpace across '
           '${debugTrackIndicesString(tracks)} on '
-          '${describeEnum(dimension)}');
+          '${dimension.name}');
     }
 
     // Grab a mutable copy of our tracks

--- a/lib/src/widgets/layout_grid.dart
+++ b/lib/src/widgets/layout_grid.dart
@@ -209,12 +209,12 @@ class LayoutGrid extends MultiChildRenderObjectWidget {
       'rowSizes',
       rowSizes,
     ));
-    properties.add(EnumProperty('autoPlacement', autoPlacement));
-    properties.add(EnumProperty('gridFit', gridFit));
+    properties.add(DiagnosticsProperty('autoPlacement', autoPlacement));
+    properties.add(DiagnosticsProperty('gridFit', gridFit));
     properties.add(DoubleProperty('columnGap', columnGap));
     properties.add(DoubleProperty('rowGap', rowGap));
     if (textDirection != null) {
-      properties.add(EnumProperty('textDirection', textDirection));
+      properties.add(DiagnosticsProperty('textDirection', textDirection));
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/shyndman/flutter_layout_grid
 
 environment:
   flutter: '>=1.25.0'
-  sdk: '>=2.14.0 <4.0.0'
+  sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
Replaced deprecated EnumProperty with DiagnosticsProperty

Bumped minimum Dart version from 2.14.0 to 2.15.0 to support .name property